### PR TITLE
Add pointerleave listener to handle missed pointerup events.

### DIFF
--- a/src/ElementHold.ts
+++ b/src/ElementHold.ts
@@ -39,6 +39,7 @@ export class ElementHold extends Hold {
 		};
 
 		element.addEventListener( 'pointerdown', onPointerDown );
+		element.addEventListener( 'pointerleave', onPointerUp );
 		document.addEventListener( 'pointerup', onPointerUp );
 		window.addEventListener( 'blur', holdEnd );
 


### PR DESCRIPTION
Added pointerleave event listener to handle cases where pointerup is not triggered. This ensures the appropriate function is called when the user clicks an element and moves the cursor outside while holding down the mouse button before releasing it.