### PR TITLE
Export KeyboardEventCode type

### DIFF
--- a/src/KeyboardKeyHold.ts
+++ b/src/KeyboardKeyHold.ts
@@ -9,7 +9,7 @@ type AllowKeys = 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'ArrowUp';
 type NumPadKeys = 'NumLock' | 'Numpad0' | 'Numpad1' | 'Numpad2' | 'Numpad3' | 'Numpad4' | 'Numpad5' | 'Numpad6' | 'Numpad7' | 'Numpad8' | 'Numpad9' | 'NumpadAdd' | 'NumpadBackspace' | 'NumpadClear' | 'NumpadClearEntry' | 'NumpadComma' | 'NumpadDecimal' | 'NumpadDivide' | 'NumpadEnter' | 'NumpadEqual' | 'NumpadHash' | 'NumpadMemoryAdd' | 'NumpadMemoryClear' | 'NumpadMemoryRecall' | 'NumpadMemoryStore' | 'NumpadMemorySubtract' | 'NumpadMultiply' | 'NumpadParenLeft' | 'NumpadParenRight' | 'NumpadStar' | 'NumpadSubtract';
 type FunctionKeys = 'Escape' | 'F1' | 'F2' | 'F3' | 'F4' | 'F5' | 'F6' | 'F7' | 'F8' | 'F9' | 'F10' | 'F11' | 'F12' | 'Fn' | 'FnLock' | 'PrintScreen' | 'ScrollLock' | 'Pause';
 type MediaKeys =  'BrowserBack' | 'BrowserFavorites' | 'BrowserForward' | 'BrowserHome' | 'BrowserRefresh' | 'BrowserSearch' | 'BrowserStop' | 'Eject' | 'LaunchApp1' | 'LaunchApp2' | 'LaunchMail' | 'MediaPlayPause' | 'MediaSelect' | 'MediaStop' | 'MediaTrackNext' | 'MediaTrackPrevious' | 'Power' | 'Sleep' | 'AudioVolumeDown' | 'AudioVolumeMute' | 'AudioVolumeUp' | 'WakeUp';
-type KeyboardEventCode = WritingSystemKeys | FunctionalKeys | CJKFunctionalKeys | ControlPadKeys | AllowKeys | NumPadKeys | FunctionKeys | MediaKeys;
+export type KeyboardEventCode = WritingSystemKeys | FunctionalKeys | CJKFunctionalKeys | ControlPadKeys | AllowKeys | NumPadKeys | FunctionKeys | MediaKeys;
 
 export class KeyboardKeyHold extends Hold {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { HOLD_EVENT_TYPE } from './constants';
 export { ElementHold } from './ElementHold';
-export { KeyboardKeyHold } from './KeyboardKeyHold';
+export { KeyboardKeyHold, KeyboardEventCode } from './KeyboardKeyHold';


### PR DESCRIPTION
This very small pull request exports `KeyboardEventCode` to enable the creation of key code arrays and the use of dynamic event assignments, for example:

```js
const keyCodes:KeyboardEventCode[] = ["Digit1", "Digit2", "Digit3"];

for (let i=0; i<keyCodes.length; i++) {
  const key = new KeyboardKeyHold(keyCodes[i], 100);
  // Add event listener that does something at position i, or whatever
}
```

or

```js
for (let i=0; i<10; i++) {
  const key = new KeyboardKeyHold(`Digit${i}` as KeyboardEventCode, 100);
  // Add event listener that does something at position i, or whatever
}
```